### PR TITLE
Updated instances of Matlabpool to Parpool

### DIFF
--- a/glmalphaup.m
+++ b/glmalphaup.m
@@ -259,7 +259,7 @@ else
     % For the SINGLE or DOUBLE POLAR CAPS
     disp('Calculating in parallel mode')
     %try
-    %    matlabpool open
+    %    parpool
     %end
 %    for m=0:maxL
 %        Vp{m+1}=[];C{m+1}=[];

--- a/glmalphauptoJp.m
+++ b/glmalphauptoJp.m
@@ -73,7 +73,7 @@ G=out2on(G(:,1:J),max(L));
 %h=waitbar(0,sprintf('Rotating the first %d Slepian functions',J));
 disp('Calculating rotations in parallel mode')
 %try
-%matlabpool open
+%parpool
 %end
 parfor j=1:J
     lmcosip=lmcosi;
@@ -85,7 +85,7 @@ parfor j=1:J
     Grot(:,j)=g(:);%tempry(ronm); 
 %    waitbar(j/J,h);
 end
-%matlabpool close
+%delete(gcp('nocreate'))
 %delete(h)
 V=V(1:J);
 % Transform back to addmout 

--- a/gradvecglmalphaup.m
+++ b/gradvecglmalphaup.m
@@ -178,7 +178,7 @@ else
         V=zeros(1,ldim);
         disp('Calculating in parallel mode')
         try
-            matlabpool open
+            parpool
         end
 
         parfor mm=1:maxL+1       

--- a/gradvecglmalphauptoJp.m
+++ b/gradvecglmalphauptoJp.m
@@ -74,7 +74,7 @@ H=out2on(H(:,1:J),max(L));
 %hh=waitbar(0,sprintf('Rotating the first %d Slepian functions',J));
 %disp('Calculating rotations in parallel mode')
 %try
-%matlabpool open
+%parpool
 %end
 
 % Avoid overwriting of dlmb matrix in parallel mode:

--- a/inoutgradvecglmalphaup.m
+++ b/inoutgradvecglmalphaup.m
@@ -239,7 +239,7 @@ else
     V=zeros(1,(maxLin+1)^2 - (min(Lin)+1)^2 + (Lout+1)^2-1);
     disp('Calculating in parallel mode')
     try
-        matlabpool open
+        parpool
     end
     % Now the same as in gradvecglmalphaup: Calculate the individual
     % solutions for the m and put them back in the right place


### PR DESCRIPTION
Matlab deprecated Matlabpool and replaced it with Parpool.  This PR fixes instances of parallel computing in Slepian_Hotel accordingly, including comments.